### PR TITLE
Add a facility to produce JSON log files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,13 @@ indent_style = space
 # Keep it the same as value of "formatting.ImportOrdering.layout" in detekt.yml.
 ij_kotlin_imports_layout = *
 
+# Kotlin-specific.
+[{*.kt,*.kts}]
+ktlint_code_style = intellij_idea
+ktlint_standard_filename = disabled
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_allow_trailing_comma = true
+
 [{*.yaml,*.yml}]
 indent_size = 2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ version.plugin.outdated=0.49.0
 
 #
 # Versions of dependencies (KMP-compatible coroutine library ends with "-native-mt"):
-version.kotlin=1.8.21
+version.kotlin=1.9.10
 version.kotlin.coroutines=1.7.3
 version.kotlin.datetime=0.4.1
 version.ktlint=0.50.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,15 +33,15 @@ build.android.compileSdk=33
 
 #
 # Versions of dependencies to keep synced with settings.gradle.kts:
-version.plugin.detekt=1.23.1
-version.plugin.ktlintGradle=11.5.1
+version.plugin.detekt=1.23.2
+version.plugin.ktlintGradle=11.6.1
 version.plugin.outdated=0.49.0
 
 #
 # Versions of dependencies (KMP-compatible coroutine library ends with "-native-mt"):
 version.kotlin=1.8.21
 version.kotlin.coroutines=1.7.3
-version.kotlin.datetime=0.4.0
+version.kotlin.datetime=0.4.1
 version.ktlint=0.50.0
 version.plugin.androidGradle=7.3.0
 version.stately.concurrency=1.2.1

--- a/shared/src/androidMain/kotlin/com/airthings/lib/logging/platform/PlatformPrinterLoggerFacilityImpl.kt
+++ b/shared/src/androidMain/kotlin/com/airthings/lib/logging/platform/PlatformPrinterLoggerFacilityImpl.kt
@@ -17,16 +17,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.airthings.lib.logging
+package com.airthings.lib.logging.platform
 
-internal const val PLATFORM_ANDROID: String = "Android"
+import android.util.Log
+import com.airthings.lib.logging.LogLevel
+import com.airthings.lib.logging.PLATFORM_ANDROID
+import com.airthings.lib.logging.facility.PlatformPrinterLoggerFacility
 
-internal const val PLATFORM_IOS: String = "iOS"
+/**
+ * Implements logging in Android via the [android.util.Log] object.
+ */
+actual class PlatformPrinterLoggerFacilityImpl : PlatformPrinterLoggerFacility {
+    override fun print(source: String, level: LogLevel, message: String) {
+        when (level) {
+            LogLevel.INFO -> Log.i(source, message)
+            LogLevel.WARNING -> Log.w(source, message)
+            LogLevel.ERROR -> Log.e(source, message)
+            LogLevel.CRASH -> Log.wtf(source, message)
+        }
+    }
 
-internal const val INITIAL_ARRAY_SIZE: Int = 50
-
-internal const val LOG_FILE_EXTENSION: String = ".log"
-
-internal const val JSON_LOG_FILE_EXTENSION: String = ".json"
-
-internal const val LOG_FILE_SEPARATOR: Char = '-'
+    override fun toString(): String = PLATFORM_ANDROID
+}

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/Constants.kt
@@ -25,8 +25,14 @@ internal const val PLATFORM_IOS: String = "iOS"
 
 internal const val INITIAL_ARRAY_SIZE: Int = 50
 
+internal const val INITIAL_BLOCK_SIZE: Int = 256
+
 internal const val LOG_FILE_EXTENSION: String = ".log"
 
 internal const val JSON_LOG_FILE_EXTENSION: String = ".json"
 
 internal const val LOG_FILE_SEPARATOR: Char = '-'
+
+internal const val COMMA: Char = ','
+
+internal const val LF: Char = '\n'

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/Constants.kt
@@ -27,12 +27,4 @@ internal const val INITIAL_ARRAY_SIZE: Int = 50
 
 internal const val INITIAL_BLOCK_SIZE: Int = 256
 
-internal const val LOG_FILE_EXTENSION: String = ".log"
-
-internal const val JSON_LOG_FILE_EXTENSION: String = ".json"
-
-internal const val LOG_FILE_SEPARATOR: Char = '-'
-
-internal const val COMMA: Char = ','
-
 internal const val LF: Char = '\n'

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
@@ -34,6 +34,7 @@ data class LogDate(
     val year: Int,
     val month: Int,
     val day: Int,
+    val separator: Char = '-',
 ) {
     /**
      * Returns a [LogDate] instance from a [LocalDateTime] component.
@@ -51,7 +52,7 @@ data class LogDate(
     override fun equals(other: Any?): Boolean =
         other is LogDate && other.year == year && other.month == month && other.day == day
 
-    override fun toString(): String = toString(LOG_FILE_SEPARATOR)
+    override fun toString(): String = toString(separator)
 
     override fun hashCode(): Int = toString(null).toIntOrNull() ?: toString().hashCode()
 }
@@ -99,8 +100,8 @@ internal fun LogDate.after(another: LogDate): Boolean = year > another.year ||
  * Returns true if this string denotes a log file created after [date], of if [date] is null, false otherwise.
  */
 internal fun String.ifAfter(date: LogDate?): Boolean {
-    val fileNameWithoutExtension = substringBeforeLast(LOG_FILE_EXTENSION)
-    val logDate = fileNameWithoutExtension.asLogDate(LOG_FILE_SEPARATOR)
+    val fileNameWithoutExtension = substringBeforeLast('.')
+    val logDate = fileNameWithoutExtension.asLogDate(date?.separator)
 
     return logDate != null && (date == null || logDate.after(date))
 }

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
@@ -21,8 +21,6 @@
 
 package com.airthings.lib.logging
 
-import com.airthings.lib.logging.facility.LOG_FILE_EXTENSION
-import com.airthings.lib.logging.facility.LOG_FILE_SEPARATOR
 import kotlinx.datetime.LocalDateTime
 
 /**

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/Logger.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/Logger.kt
@@ -787,10 +787,6 @@ class Logger(
                 source = source,
                 level = level,
                 message = message,
-            )
-            log(
-                source = source,
-                level = level,
                 error = error,
             )
         }
@@ -827,10 +823,6 @@ class Logger(
                 source = source,
                 level = level,
                 message = message,
-            )
-            log(
-                source = source,
-                level = level,
                 error = error,
             )
         }

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/LoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/LoggerFacility.kt
@@ -46,7 +46,11 @@ interface LoggerFacility {
      * @param level The level at which to log the message.
      * @param message The message's details.
      */
-    fun log(source: String, level: LogLevel, message: LogMessage)
+    fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+    )
 
     /**
      * Logs an error with this facility.
@@ -55,7 +59,26 @@ interface LoggerFacility {
      * @param level The level at which to log the error.
      * @param error The error's details.
      */
-    fun log(source: String, level: LogLevel, error: Throwable)
+    fun log(
+        source: String,
+        level: LogLevel,
+        error: Throwable,
+    )
+
+    /**
+     * Logs a message and an error with this facility.
+     *
+     * @param source A source tag that identifies the message.
+     * @param level The level at which to log the message.
+     * @param message The message's details.
+     * @param error The error's details.
+     */
+    fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+        error: Throwable,
+    )
 
     /**
      * Contains controller functions to define logging facilities.

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/FileLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/FileLoggerFacility.kt
@@ -174,6 +174,24 @@ class FileLoggerFacility(
         }
     }
 
+    override fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+        error: Throwable,
+    ) {
+        log(
+            source = source,
+            level = level,
+            message = message,
+        )
+        log(
+            source = source,
+            level = level,
+            error = error,
+        )
+    }
+
     /**
      * Scans the [baseFolder] and returns the list of log files residing in it.
      */

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/FileLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/FileLoggerFacility.kt
@@ -27,14 +27,14 @@ import com.airthings.lib.logging.LogMessage
 import com.airthings.lib.logging.LoggerFacility
 import com.airthings.lib.logging.dateStamp
 import com.airthings.lib.logging.datetimeStampPrefix
+import com.airthings.lib.logging.platform.PlatformDirectoryListing
+import com.airthings.lib.logging.platform.PlatformFileInputOutput
+import com.airthings.lib.logging.platform.PlatformFileInputOutputImpl
+import com.airthings.lib.logging.platform.PlatformFileInputOutputNotifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-
-internal const val INITIAL_ARRAY_SIZE: Int = 50
-internal const val LOG_FILE_EXTENSION: String = ".log"
-internal const val LOG_FILE_SEPARATOR: Char = '-'
 
 /**
  * A [LoggerFacility] that persists log messages to the file system.
@@ -218,89 +218,3 @@ class FileLoggerFacility(
         const val LOG_TAG: String = "FileLoggerFacility"
     }
 }
-
-/**
- * Defines a contract to retrieve the listing of files residing inside a directory.
- */
-interface PlatformDirectoryListing {
-    /**
-     * Scans a [directory][path] and returns the list of log files residing in it.
-     *
-     * @param path The location of the directory to scan.
-     */
-    suspend fun of(path: String): Collection<String>
-
-    /**
-     * Scans a [directory][path] and returns the list of log files residing in it that were created after a certain date.
-     *
-     * @param path The location of the directory to scan.
-     * @param date The date from which log files should be considered.
-     */
-    suspend fun of(path: String, date: LogDate): Collection<String>
-}
-
-/**
- * Defines a contract to perform common input/output on files.
- *
- * The implementation of this interface is platform-specific and isn't in the shared module.
- */
-internal interface PlatformFileInputOutput : PlatformDirectoryListing {
-    /**
-     * The character used to separate components of a path (`/`, or `\`, etc.)
-     */
-    val pathSeparator: Char
-
-    /**
-     * Returns true if the provided path points to a directory, false otherwise.
-     *
-     * @param path The location of the directory.
-     */
-    suspend fun isDirectory(path: String): Boolean
-
-    /**
-     * Creates the provided [directory path][path], including any intermediary ones, and returns true on success,
-     * false otherwise.
-     *
-     * @param path The location of the directory.
-     */
-    suspend fun mkdirs(path: String): Boolean
-
-    /**
-     * Appends arbitrary bytes to a log file.
-     *
-     * @param path The location of the log file.
-     * @param contents The contents to append to the file.
-     */
-    suspend fun append(path: String, contents: String)
-
-    /**
-     * Ensures that a log file exists at a specific location, creating it if necessary.
-     *
-     * @param path The location of the log file.
-     */
-    suspend fun ensure(path: String)
-}
-
-/**
- * Defines a contract that notifies about opening and closing log files.
- */
-interface PlatformFileInputOutputNotifier {
-    /**
-     * Invoked when a new log file has been created.
-     *
-     * @param path The location of the log file.
-     */
-    fun onLogFileOpened(path: String)
-
-    /**
-     * Invoked when a log file has been closed.
-     *
-     * @param path The location of the log file.
-     */
-    fun onLogFileClosed(path: String)
-}
-
-/**
- * Expect declaration for a [PlatformFileInputOutput].
- */
-internal expect class PlatformFileInputOutputImpl() : PlatformFileInputOutput

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/FirebaseLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/FirebaseLoggerFacility.kt
@@ -67,6 +67,24 @@ class FirebaseLoggerFacility(
         }
     }
 
+    override fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+        error: Throwable,
+    ) {
+        log(
+            source = source,
+            level = level,
+            message = message,
+        )
+        log(
+            source = source,
+            level = level,
+            error = error,
+        )
+    }
+
     /**
      * Sets the user identity that will be appended to the logs.
      *

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
@@ -17,16 +17,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.airthings.lib.logging
-
-internal const val PLATFORM_ANDROID: String = "Android"
-
-internal const val PLATFORM_IOS: String = "iOS"
-
-internal const val INITIAL_ARRAY_SIZE: Int = 50
-
-internal const val LOG_FILE_EXTENSION: String = ".log"
-
-internal const val JSON_LOG_FILE_EXTENSION: String = ".json"
-
-internal const val LOG_FILE_SEPARATOR: Char = '-'
+package com.airthings.lib.logging.facility

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
@@ -21,7 +21,6 @@ package com.airthings.lib.logging.facility
 
 import co.touchlab.stately.concurrency.AtomicReference
 import co.touchlab.stately.concurrency.value
-import com.airthings.lib.logging.COMMA
 import com.airthings.lib.logging.INITIAL_BLOCK_SIZE
 import com.airthings.lib.logging.LogArgument
 import com.airthings.lib.logging.LogDate
@@ -245,6 +244,7 @@ class JsonLoggerFacility(
         private const val MESSAGE_KEY: String = "message"
         private const val ERROR_KEY: String = "error"
         private const val ARGS_KEY: String = "args"
+        private const val COMMA: Char = ','
         private const val ARRAY_OPEN: Char = '['
         private const val ARRAY_CLOSE: Char = ']'
         private const val CURLY_OPEN: Char = '{'

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
@@ -193,6 +193,29 @@ class JsonLoggerFacility(
         }
     }
 
+    override fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+        error: Throwable,
+    ) {
+        withLogLevel(level) { logFile, prefix ->
+            val jsonOutput = jsonOutput(
+                source = source,
+                time = utc(),
+                level = level,
+                message = message.message,
+                error = error,
+                args = message.args,
+            )
+            io.write(
+                path = logFile,
+                position = -1L,
+                contents = "$prefix$jsonOutput$ARRAY_CLOSE",
+            )
+        }
+    }
+
     /**
      * Scans the [baseFolder] and returns the list of log files residing in it.
      */

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
@@ -18,3 +18,305 @@
  */
 
 package com.airthings.lib.logging.facility
+
+import co.touchlab.stately.concurrency.AtomicReference
+import co.touchlab.stately.concurrency.value
+import com.airthings.lib.logging.COMMA
+import com.airthings.lib.logging.INITIAL_BLOCK_SIZE
+import com.airthings.lib.logging.LogArgument
+import com.airthings.lib.logging.LogDate
+import com.airthings.lib.logging.LogLevel
+import com.airthings.lib.logging.LogMessage
+import com.airthings.lib.logging.LoggerFacility
+import com.airthings.lib.logging.dateStamp
+import com.airthings.lib.logging.datetimeStamp
+import com.airthings.lib.logging.datetimeStampPrefix
+import com.airthings.lib.logging.platform.PlatformDirectoryListing
+import com.airthings.lib.logging.platform.PlatformFileInputOutput
+import com.airthings.lib.logging.platform.PlatformFileInputOutputImpl
+import com.airthings.lib.logging.platform.PlatformFileInputOutputNotifier
+import com.airthings.lib.logging.utc
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDateTime
+
+/**
+ * A [LoggerFacility] that persists log messages in a JSON file.
+ *
+ * @param minimumLogLevel Only log messages and errors that are equal or greater than this level.
+ * @param baseFolder The base folder where log files will be written, excluding the trailing `/`.
+ * @param coroutineScope A coroutine scope to run blocking i/o on.
+ * @param notifier An optional implementation of [PlatformFileInputOutputNotifier].
+ */
+@Suppress("unused")
+class JsonLoggerFacility(
+    private val minimumLogLevel: LogLevel,
+    private val baseFolder: String,
+    private val coroutineScope: CoroutineScope,
+    private val notifier: PlatformFileInputOutputNotifier?,
+) : LoggerFacility {
+    /**
+     * Returns a [JsonLoggerFacility] instance that handles only [WARNING][LogLevel.WARNING],
+     * [ERROR][LogLevel.ERROR] and [CRASH][LogLevel.CRASH] logs.
+     *
+     * If you'd like to log [INFO][LogLevel.INFO] also, then use the main constructor.
+     *
+     * @param baseFolder The base folder where log files will be written, excluding the trailing `/`.
+     * @param scope A coroutine scope to run blocking i/o on.
+     * @param notifier An optional implementation of [PlatformFileInputOutputNotifier].
+     */
+    constructor(
+        baseFolder: String,
+        scope: CoroutineScope,
+        notifier: PlatformFileInputOutputNotifier?,
+    ) : this(
+        minimumLogLevel = LogLevel.WARNING,
+        baseFolder = baseFolder,
+        coroutineScope = scope,
+        notifier = notifier,
+    )
+
+    /**
+     * Returns a [JsonLoggerFacility] instance without a notifier.
+     *
+     * @param minimumLogLevel Only log messages and errors that are equal or greater than this level.
+     * @param baseFolder The base folder where log files will be written, excluding the trailing `/`.
+     * @param scope A coroutine scope to run blocking i/o on.
+     */
+    constructor(
+        minimumLogLevel: LogLevel,
+        baseFolder: String,
+        scope: CoroutineScope,
+    ) : this(
+        minimumLogLevel = minimumLogLevel,
+        baseFolder = baseFolder,
+        coroutineScope = scope,
+        notifier = null,
+    )
+
+    /**
+     * Returns a [JsonLoggerFacility] instance using a default [CoroutineScope].
+     *
+     * @param minimumLogLevel Only log messages and errors that are equal or greater than this level.
+     * @param baseFolder The base folder where log files will be written, excluding the trailing `/`.
+     * @param notifier An optional implementation of [PlatformFileInputOutputNotifier].
+     */
+    constructor(
+        minimumLogLevel: LogLevel,
+        baseFolder: String,
+        notifier: PlatformFileInputOutputNotifier?,
+    ) : this(
+        minimumLogLevel = minimumLogLevel,
+        baseFolder = baseFolder,
+        coroutineScope = FileLoggerFacility.loggerCoroutineScope(),
+        notifier = notifier,
+    )
+
+    /**
+     * Returns a [JsonLoggerFacility] instance that handles only [WARNING][LogLevel.WARNING],
+     * [ERROR][LogLevel.ERROR] and [CRASH][LogLevel.CRASH] logs.
+     *
+     * If you'd like to log [INFO][LogLevel.INFO] also, then use the main constructor.
+     *
+     * @param baseFolder The base folder where log files will be written, excluding the trailing `/`.
+     */
+    constructor(
+        minimumLogLevel: LogLevel,
+        baseFolder: String,
+    ) : this(
+        minimumLogLevel = minimumLogLevel,
+        baseFolder = baseFolder,
+        coroutineScope = FileLoggerFacility.loggerCoroutineScope(),
+        notifier = null,
+    )
+
+    private val io: PlatformFileInputOutput = PlatformFileInputOutputImpl()
+    private val currentLogFile = AtomicReference<String?>(null)
+
+    init {
+        coroutineScope.launch {
+            if (!io.isDirectory(baseFolder) && !io.mkdirs(baseFolder)) {
+                throw IllegalArgumentException("Base log folder is invalid: $baseFolder")
+            }
+        }
+    }
+
+    /**
+     * Returns the platform-dependent [PlatformDirectoryListing] instance.
+     */
+    val listing: PlatformDirectoryListing
+        get() = io
+
+    override fun toString(): String = "JsonLoggerFacility($io)"
+
+    override fun isEnabled(): Boolean = true
+
+    override fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+    ) {
+        withLogLevel(level) { logFile ->
+            val jsonOutput = jsonOutput(
+                source = source,
+                time = utc(),
+                level = level,
+                message = message.message,
+                error = null,
+                args = message.args,
+            )
+            io.write(
+                path = logFile,
+                position = -1L,
+                contents = "$jsonOutput$ARRAY_CLOSE",
+            )
+        }
+    }
+
+    override fun log(
+        source: String,
+        level: LogLevel,
+        error: Throwable,
+    ) {
+        withLogLevel(level) { logFile ->
+            val jsonOutput = jsonOutput(
+                source = source,
+                time = utc(),
+                level = level,
+                message = null,
+                error = error,
+                args = null,
+            )
+            io.write(
+                path = logFile,
+                position = -1L,
+                contents = "$jsonOutput$ARRAY_CLOSE",
+            )
+
+            io.append(
+                path = logFile,
+                contents = "${datetimeStampPrefix()} ${PrinterLoggerFacility.format(level, error).trim()}",
+            )
+        }
+    }
+
+    /**
+     * Scans the [baseFolder] and returns the list of log files residing in it.
+     */
+    suspend fun files(): Collection<String> = io.of(baseFolder)
+
+    /**
+     * Scans the [baseFolder] and returns the list of log files residing in it that were created after a certain date.
+     *
+     * @param date The date from which log files should be considered.
+     */
+    suspend fun files(date: LogDate): Collection<String> = io.of(baseFolder, date)
+
+    private fun withLogLevel(
+        level: LogLevel,
+        action: suspend (String) -> Unit,
+    ) {
+        if (level.value < minimumLogLevel.value) {
+            return
+        }
+
+        coroutineScope.launch {
+            val logFile = "$baseFolder${io.pathSeparator}${dateStamp(null)}.log"
+            val currentLogFileLocked = currentLogFile.value
+
+            if (currentLogFileLocked != logFile) {
+                if (currentLogFileLocked != null) {
+                    notifier?.onLogFileClosed(currentLogFileLocked)
+                }
+                io.ensure(logFile)
+                currentLogFile.set(logFile)
+                notifier?.onLogFileOpened(logFile)
+            }
+
+            action(logFile)
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG: String = "JsonLoggerFacility"
+        private const val SOURCE_KEY: String = "source"
+        private const val TIME_KEY: String = "time"
+        private const val LEVEL_KEY: String = "level"
+        private const val MESSAGE_KEY: String = "message"
+        private const val ERROR_KEY: String = "error"
+        private const val ARGS_KEY: String = "args"
+        private const val ARRAY_OPEN: Char = '['
+        private const val ARRAY_CLOSE: Char = ']'
+        private const val CURLY_OPEN: Char = '{'
+        private const val CURLY_CLOSE: Char = '}'
+
+        private fun String.jsonEscape(): String = replace("\\", "\\\\")
+            .replace("/", "\\/")
+            .replace("\"", "\\\"")
+            .replace("\b", "\\b")
+            .replace("\r", "\\r")
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+
+        private fun String.jsonQuote(): String = "\"${jsonEscape()}\""
+
+        private fun Pair<String, String>.jsonEntry(): String = "${first.jsonQuote()}:${second.jsonQuote()}"
+
+        private fun List<LogArgument>.jsonEntry(): String = StringBuilder(INITIAL_BLOCK_SIZE)
+            .apply {
+                append(CURLY_OPEN)
+
+                forEach { arg: LogArgument ->
+                    val value = arg.value?.toString()
+                    if (value != null) {
+                        append((arg.label to value).jsonEntry())
+                        append(COMMA)
+                    }
+                }
+
+                // Remove the last comma if needed.
+                if (length > 1) {
+                    setLength(length - 1)
+                }
+
+                append(CURLY_CLOSE)
+            }
+            .toString()
+
+        private fun jsonOutput(
+            source: String,
+            time: LocalDateTime,
+            level: LogLevel,
+            message: String?,
+            error: Throwable?,
+            args: List<LogArgument>?,
+        ): String = StringBuilder(INITIAL_BLOCK_SIZE)
+            .apply {
+                append(CURLY_OPEN)
+
+                append((SOURCE_KEY to source).jsonEntry())
+                append(COMMA)
+                append((TIME_KEY to datetimeStamp(time)).jsonEntry())
+                append(COMMA)
+                append((LEVEL_KEY to "$level").jsonEntry())
+
+                if (message != null) {
+                    append(COMMA)
+                    append((MESSAGE_KEY to message).jsonEntry())
+                }
+
+                if (error != null) {
+                    append(COMMA)
+                    append((ERROR_KEY to error.stackTraceToString()).jsonEntry())
+                }
+
+                if (!args.isNullOrEmpty()) {
+                    append(COMMA)
+                    append(args.jsonEntry())
+                }
+
+                append(CURLY_CLOSE)
+            }
+            .toString()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/MockPrinterLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/MockPrinterLoggerFacility.kt
@@ -30,11 +30,28 @@ import com.airthings.lib.logging.LoggerFacility
 open class MockPrinterLoggerFacility : LoggerFacility {
     override fun isEnabled(): Boolean = true
 
-    override fun log(source: String, level: LogLevel, message: LogMessage) {
+    override fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+    ) {
         // NO-OP.
     }
 
-    override fun log(source: String, level: LogLevel, error: Throwable) {
+    override fun log(
+        source: String,
+        level: LogLevel,
+        error: Throwable,
+    ) {
+        // NO-OP.
+    }
+
+    override fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+        error: Throwable,
+    ) {
         // NO-OP.
     }
 

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/PrinterLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/PrinterLoggerFacility.kt
@@ -22,6 +22,7 @@ package com.airthings.lib.logging.facility
 import com.airthings.lib.logging.LogLevel
 import com.airthings.lib.logging.LogMessage
 import com.airthings.lib.logging.LoggerFacility
+import com.airthings.lib.logging.platform.PlatformPrinterLoggerFacilityImpl
 
 /**
  * A [LoggerFacility] that prints log messages to standard output using a platform-specific method.
@@ -93,8 +94,3 @@ interface PlatformPrinterLoggerFacility {
      */
     fun print(source: String, level: LogLevel, message: String)
 }
-
-/**
- * Expect declaration for a [PlatformPrinterLoggerFacility].
- */
-expect class PlatformPrinterLoggerFacilityImpl() : PlatformPrinterLoggerFacility

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/PrinterLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/facility/PrinterLoggerFacility.kt
@@ -32,7 +32,11 @@ class PrinterLoggerFacility : LoggerFacility {
 
     override fun isEnabled(): Boolean = true
 
-    override fun log(source: String, level: LogLevel, message: LogMessage) {
+    override fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+    ) {
         facility.print(
             source = source,
             level = level,
@@ -43,7 +47,11 @@ class PrinterLoggerFacility : LoggerFacility {
         )
     }
 
-    override fun log(source: String, level: LogLevel, error: Throwable) {
+    override fun log(
+        source: String,
+        level: LogLevel,
+        error: Throwable,
+    ) {
         facility.print(
             source = source,
             level = level,
@@ -51,6 +59,24 @@ class PrinterLoggerFacility : LoggerFacility {
                 level = level,
                 error = error,
             ),
+        )
+    }
+
+    override fun log(
+        source: String,
+        level: LogLevel,
+        message: LogMessage,
+        error: Throwable,
+    ) {
+        log(
+            source = source,
+            level = level,
+            message = message,
+        )
+        log(
+            source = source,
+            level = level,
+            error = error,
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformDirectoryListing.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformDirectoryListing.kt
@@ -17,24 +17,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.airthings.lib.logging.facility
+package com.airthings.lib.logging.platform
 
-import android.util.Log
-import com.airthings.lib.logging.LogLevel
-import com.airthings.lib.logging.PLATFORM_ANDROID
+import com.airthings.lib.logging.LogDate
 
 /**
- * Implements logging in Android via the [android.util.Log] object.
+ * Defines a contract to retrieve the listing of files residing inside a directory.
  */
-actual class PlatformPrinterLoggerFacilityImpl : PlatformPrinterLoggerFacility {
-    override fun print(source: String, level: LogLevel, message: String) {
-        when (level) {
-            LogLevel.INFO -> Log.i(source, message)
-            LogLevel.WARNING -> Log.w(source, message)
-            LogLevel.ERROR -> Log.e(source, message)
-            LogLevel.CRASH -> Log.wtf(source, message)
-        }
-    }
+interface PlatformDirectoryListing {
+    /**
+     * Scans a [directory][path] and returns the list of log files residing in it.
+     *
+     * @param path The location of the directory to scan.
+     */
+    suspend fun of(path: String): Collection<String>
 
-    override fun toString(): String = PLATFORM_ANDROID
+    /**
+     * Scans a [directory][path] and returns the list of log files residing in it that were created after a certain date.
+     *
+     * @param path The location of the directory to scan.
+     * @param date The date from which log files should be considered.
+     */
+    suspend fun of(path: String, date: LogDate): Collection<String>
 }

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutput.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutput.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Airthings ASA. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.airthings.lib.logging.platform
+
+/**
+ * Defines a contract to perform common input/output on files.
+ *
+ * The implementation of this interface is platform-specific and isn't in the shared module.
+ */
+internal interface PlatformFileInputOutput : PlatformDirectoryListing {
+    /**
+     * The character used to separate components of a path (`/`, or `\`, etc.)
+     */
+    val pathSeparator: Char
+
+    /**
+     * Returns true if the provided path points to a directory, false otherwise.
+     *
+     * @param path The location of the directory.
+     */
+    suspend fun isDirectory(path: String): Boolean
+
+    /**
+     * Creates the provided [directory path][path], including any intermediary ones, and returns true on success,
+     * false otherwise.
+     *
+     * @param path The location of the directory.
+     */
+    suspend fun mkdirs(path: String): Boolean
+
+    /**
+     * Writes arbitrary bytes to a file starting at a specific position.
+     *
+     * For ease of use, [position] accepts negative values too. The difference between positive and negative
+     * values is where from we start counting bytes from:
+     *
+     * - Positive [position] value: Number of bytes to count from starting at the beginning of the file.
+     * - Negative [position] value: Number of bytes to count from starting at EOF (end-of-file).
+     *
+     * Note: Subsequent bytes after [position] are overwritten.
+     *
+     * @param path The location of the file.
+     * @param position Number of bytes to position the file pointer at.
+     * @param contents The contents to write to the file.
+     */
+    suspend fun write(path: String, position: Long, contents: String)
+
+    /**
+     * Appends arbitrary bytes to a file.
+     *
+     * @param path The location of the file.
+     * @param contents The contents to append to the file.
+     */
+    suspend fun append(path: String, contents: String)
+
+    /**
+     * Ensures that a file exists at a specific location, creating it if necessary.
+     *
+     * @param path The location of the file.
+     */
+    suspend fun ensure(path: String)
+}
+
+/**
+ * Platform-specific implementation of [PlatformFileInputOutput].
+ */
+internal expect class PlatformFileInputOutputImpl() : PlatformFileInputOutput
+
+/**
+ * Returns the absolute position within a file based on a relative position.
+ */
+internal fun Long.relativeToSize(size: Long): Long = (coerceAtMost(0L) + size).coerceIn(0L..size)

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutput.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutput.kt
@@ -86,4 +86,4 @@ internal expect class PlatformFileInputOutputImpl() : PlatformFileInputOutput
 /**
  * Returns the absolute position within a file based on a relative position.
  */
-internal fun Long.relativeToSize(size: Long): Long = (coerceAtMost(0L) + size).coerceIn(0L..size)
+internal fun Long.relativeToSize(size: Long): Long = (this + (if (this < 0L) size else 0L)).coerceIn(0L..size)

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutput.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutput.kt
@@ -46,6 +46,13 @@ internal interface PlatformFileInputOutput : PlatformDirectoryListing {
     suspend fun mkdirs(path: String): Boolean
 
     /**
+     * Returns the size, in bytes, of a file.
+     *
+     * @param path The location of the file.
+     */
+    suspend fun size(path: String): Long
+
+    /**
      * Writes arbitrary bytes to a file starting at a specific position.
      *
      * For ease of use, [position] accepts negative values too. The difference between positive and negative

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputNotifier.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputNotifier.kt
@@ -17,16 +17,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.airthings.lib.logging
+package com.airthings.lib.logging.platform
 
-internal const val PLATFORM_ANDROID: String = "Android"
+/**
+ * Defines a contract that notifies about opening and closing log files.
+ */
+interface PlatformFileInputOutputNotifier {
+    /**
+     * Invoked when a new log file has been created.
+     *
+     * @param path The location of the log file.
+     */
+    fun onLogFileOpened(path: String)
 
-internal const val PLATFORM_IOS: String = "iOS"
-
-internal const val INITIAL_ARRAY_SIZE: Int = 50
-
-internal const val LOG_FILE_EXTENSION: String = ".log"
-
-internal const val JSON_LOG_FILE_EXTENSION: String = ".json"
-
-internal const val LOG_FILE_SEPARATOR: Char = '-'
+    /**
+     * Invoked when a log file has been closed.
+     *
+     * @param path The location of the log file.
+     */
+    fun onLogFileClosed(path: String)
+}

--- a/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PrinterLoggerFacility.kt
+++ b/shared/src/commonMain/kotlin/com/airthings/lib/logging/platform/PrinterLoggerFacility.kt
@@ -17,16 +17,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.airthings.lib.logging
+package com.airthings.lib.logging.platform
 
-internal const val PLATFORM_ANDROID: String = "Android"
+import com.airthings.lib.logging.facility.PlatformPrinterLoggerFacility
 
-internal const val PLATFORM_IOS: String = "iOS"
-
-internal const val INITIAL_ARRAY_SIZE: Int = 50
-
-internal const val LOG_FILE_EXTENSION: String = ".log"
-
-internal const val JSON_LOG_FILE_EXTENSION: String = ".json"
-
-internal const val LOG_FILE_SEPARATOR: Char = '-'
+/**
+ * Expect declaration for a [PlatformPrinterLoggerFacility].
+ */
+expect class PlatformPrinterLoggerFacilityImpl() : PlatformPrinterLoggerFacility

--- a/shared/src/iosMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputImpl.kt
+++ b/shared/src/iosMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputImpl.kt
@@ -23,8 +23,10 @@ import com.airthings.lib.logging.INITIAL_ARRAY_SIZE
 import com.airthings.lib.logging.LogDate
 import com.airthings.lib.logging.PLATFORM_IOS
 import com.airthings.lib.logging.ifAfter
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.BooleanVar
 import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCObjectVar
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
@@ -43,6 +45,7 @@ import platform.posix.fopen
 import platform.posix.fputs
 import platform.posix.fseek
 
+@OptIn(ExperimentalForeignApi::class)
 internal actual class PlatformFileInputOutputImpl : PlatformFileInputOutput {
     override val pathSeparator: Char = '/'
 
@@ -171,6 +174,7 @@ internal actual class PlatformFileInputOutputImpl : PlatformFileInputOutput {
  * If after running [block] there is an error, then [fallback] is returned.
  * Otherwise, the actual result of [block] is returned.
  */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 private fun <T> nsErrorWrapper(
     fallback: T,
     block: (errorPointer: CPointer<ObjCObjectVar<NSError?>>) -> T,

--- a/shared/src/iosMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputImpl.kt
+++ b/shared/src/iosMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputImpl.kt
@@ -70,7 +70,7 @@ internal actual class PlatformFileInputOutputImpl : PlatformFileInputOutput {
     override suspend fun write(path: String, position: Long, contents: String) {
         nsErrorWrapper(Unit) {
             val file = fopen(__filename = path, __mode = "a")
-                ?: throw IllegalArgumentException("Cannot open file for writing: $path")
+                ?: throw IllegalArgumentException("Cannot open file for appending: $path")
 
             val size = NSFileManager.defaultManager
                 .attributesOfFileSystemForPath(path, it)

--- a/shared/src/iosMain/kotlin/com/airthings/lib/logging/platform/PlatformPrinterLoggerFacilityImpl.kt
+++ b/shared/src/iosMain/kotlin/com/airthings/lib/logging/platform/PlatformPrinterLoggerFacilityImpl.kt
@@ -17,10 +17,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.airthings.lib.logging.facility
+package com.airthings.lib.logging.platform
 
 import com.airthings.lib.logging.LogLevel
 import com.airthings.lib.logging.PLATFORM_IOS
+import com.airthings.lib.logging.facility.PlatformPrinterLoggerFacility
 import platform.Foundation.NSLog
 
 /**


### PR DESCRIPTION
An example of the format of the resulting JSON file follows:

```json
[
  {
    "source": "SomeRepositoryImpl.kt",
    "time": "2023-10-13 14:09:34",
    "level": "INFO",
    "message": "The device has been added.",
    "args": {
      "serial_number": "123456789",
      "is_hub": true,
      "room": "Some room",
      "other_rooms": 3,
    }
  },
  {
    "source": "AnotherRepositoryImpl.kt",
    "time": "2023-10-12 11:29:41",
    "level": "ERROR",
    "message": "Unable to add a new room.",
    "error": "A log trace is written here and it may\ncontain multiple lines and consequitive\n         spaces  in the trace.",
    "args": {
      "room": "Another room",
      "other_rooms": 3,
    }
  }
]
```