### PR TITLE
Fix log files not being uploaded because of a `LogDate` being `null`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 rootProject.group = "com.airthings.lib"
-rootProject.version = "0.1.4"
+rootProject.version = "0.1.5"
 
 buildscript {
     repositories {

--- a/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
+++ b/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
@@ -34,7 +34,6 @@ data class LogDate(
     val year: Int,
     val month: Int,
     val day: Int,
-    val separator: Char = '-',
 ) {
     /**
      * Returns a [LogDate] instance from a [LocalDateTime] component.
@@ -52,9 +51,13 @@ data class LogDate(
     override fun equals(other: Any?): Boolean =
         other is LogDate && other.year == year && other.month == month && other.day == day
 
-    override fun toString(): String = toString(separator)
+    override fun toString(): String = toString(SEPARATOR)
 
     override fun hashCode(): Int = toString(null).toIntOrNull() ?: toString().hashCode()
+
+    companion object {
+        const val SEPARATOR = '-'
+    }
 }
 
 internal fun LogDate.toString(separator: Char?): String = StringBuilder(10)
@@ -101,7 +104,7 @@ internal fun LogDate.after(another: LogDate): Boolean = year > another.year ||
  */
 internal fun String.ifAfter(date: LogDate?): Boolean {
     val fileNameWithoutExtension = substringBeforeLast('.')
-    val logDate = fileNameWithoutExtension.asLogDate(date?.separator)
+    val logDate = fileNameWithoutExtension.asLogDate(LogDate.SEPARATOR)
 
     return logDate != null && (date == null || logDate.after(date))
 }

--- a/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
+++ b/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
@@ -21,6 +21,7 @@
 
 package com.airthings.lib.logging
 
+import com.airthings.lib.logging.LogDate.Companion.SEPARATOR
 import kotlinx.datetime.LocalDateTime
 
 /**
@@ -29,11 +30,13 @@ import kotlinx.datetime.LocalDateTime
  * @param year The year part of the date.
  * @param month The month part of the date, within the range of 1..12.
  * @param day The day part of the date, within the range of 1..31.
+ * @param separator The character used to separate the date parts, defaults to [SEPARATOR].
  */
 data class LogDate(
     val year: Int,
     val month: Int,
     val day: Int,
+    val separator: Char = '-',
 ) {
     /**
      * Returns a [LogDate] instance from a [LocalDateTime] component.
@@ -51,11 +54,14 @@ data class LogDate(
     override fun equals(other: Any?): Boolean =
         other is LogDate && other.year == year && other.month == month && other.day == day
 
-    override fun toString(): String = toString(SEPARATOR)
+    override fun toString(): String = toString(separator)
 
     override fun hashCode(): Int = toString(null).toIntOrNull() ?: toString().hashCode()
 
     companion object {
+        /**
+         * The character used to separate date parts, f.ex: `2023-08-23`.
+         */
         const val SEPARATOR = '-'
     }
 }
@@ -104,7 +110,7 @@ internal fun LogDate.after(another: LogDate): Boolean = year > another.year ||
  */
 internal fun String.ifAfter(date: LogDate?): Boolean {
     val fileNameWithoutExtension = substringBeforeLast('.')
-    val logDate = fileNameWithoutExtension.asLogDate(LogDate.SEPARATOR)
+    val logDate = fileNameWithoutExtension.asLogDate(date?.separator ?: SEPARATOR)
 
     return logDate != null && (date == null || logDate.after(date))
 }

--- a/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
+++ b/src/commonMain/kotlin/com/airthings/lib/logging/LogDate.kt
@@ -21,7 +21,6 @@
 
 package com.airthings.lib.logging
 
-import com.airthings.lib.logging.LogDate.Companion.SEPARATOR
 import kotlinx.datetime.LocalDateTime
 
 /**
@@ -110,7 +109,7 @@ internal fun LogDate.after(another: LogDate): Boolean = year > another.year ||
  */
 internal fun String.ifAfter(date: LogDate?): Boolean {
     val fileNameWithoutExtension = substringBeforeLast('.')
-    val logDate = fileNameWithoutExtension.asLogDate(date?.separator ?: SEPARATOR)
+    val logDate = fileNameWithoutExtension.asLogDate(date?.separator ?: LogDate.SEPARATOR)
 
     return logDate != null && (date == null || logDate.after(date))
 }


### PR DESCRIPTION
```kotlin
val logDate = fileNameWithoutExtension.asLogDate(date?.separator)
``` 

produces `null` when `date` is null, which happens to be the case when the `FileLoggerFacility` is used by clients. If `logDate` is `null`, `String.ifAfter` will return `false`, and this might cause log files to be not uploaded.

@airxnoor Let me know if you want to solve this in another way.