### PR TITLE
Fix a bug when preparing the base logging directory

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.2.0 - March 26, 2024
+• Fix a bug where the log folder wasn't created.
+• Simplify the platform's file i/o public interface.
+
 0.1.5 - November 17, 2023
 • Fix log files not being uploaded because of a `LogDate` being `null`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 rootProject.group = "com.airthings.lib"
-rootProject.version = "0.1.5"
+rootProject.version = "0.2.0"
 
 buildscript {
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,10 +19,11 @@
 
 # Gradle/KMP options:
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+kotlin.code.style=official
 kotlin.mpp.androidSourceSetLayoutVersion1.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
-kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
+kotlin.mpp.applyDefaultHierarchyTemplate=false
 kotlin.native.cacheKind.iosArm64=none
 kotlin.native.ignoreDisabledTargets=true
 
@@ -43,7 +44,7 @@ version.plugin.detekt=1.23.3
 version.plugin.outdated=0.49.0
 
 # Dependencies:
-version.kotlin=1.9.10
+version.kotlin=1.9.22
 version.kotlin.coroutines=1.7.3
 version.kotlin.datetime=0.4.1
-version.stately.concurrency=1.2.1
+version.stately.concurrency=1.2.3

--- a/src/androidMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputImpl.kt
+++ b/src/androidMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputImpl.kt
@@ -31,9 +31,13 @@ internal actual class PlatformFileInputOutputImpl : PlatformFileInputOutput {
 
     override val pathSeparator: Char = File.separatorChar
 
-    override suspend fun isDirectory(path: String): Boolean = File(path).isDirectory
+    override suspend fun mkdirs(path: String): Boolean {
+        val pathFile = File(path)
 
-    override suspend fun mkdirs(path: String): Boolean = File(path).mkdirs()
+        pathFile.mkdirs()
+
+        return pathFile.isDirectory
+    }
 
     override suspend fun size(path: String): Long = File(path).length()
 

--- a/src/commonMain/kotlin/com/airthings/lib/logging/facility/FileLoggerFacility.kt
+++ b/src/commonMain/kotlin/com/airthings/lib/logging/facility/FileLoggerFacility.kt
@@ -132,6 +132,8 @@ class FileLoggerFacility(
 
     init {
         coroutineScope.launch {
+            // Please note: The call to `io.mkdirs()` returns true if the directory exists, which may be
+            // different from the platform's implementation.
             if (!io.mkdirs(baseFolder)) {
                 throw IllegalArgumentException("Base log folder is invalid: $baseFolder")
             }

--- a/src/commonMain/kotlin/com/airthings/lib/logging/facility/FileLoggerFacility.kt
+++ b/src/commonMain/kotlin/com/airthings/lib/logging/facility/FileLoggerFacility.kt
@@ -132,7 +132,7 @@ class FileLoggerFacility(
 
     init {
         coroutineScope.launch {
-            if (!io.isDirectory(baseFolder) && !io.mkdirs(baseFolder)) {
+            if (!io.mkdirs(baseFolder)) {
                 throw IllegalArgumentException("Base log folder is invalid: $baseFolder")
             }
         }

--- a/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
+++ b/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
@@ -133,6 +133,8 @@ class JsonLoggerFacility(
 
     init {
         coroutineScope.launch {
+            // Please note: The call to `io.mkdirs()` returns true if the directory exists, which may be
+            // different from the platform's implementation.
             if (!io.mkdirs(baseFolder)) {
                 throw IllegalArgumentException("Base log folder is invalid: $baseFolder")
             }

--- a/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
+++ b/src/commonMain/kotlin/com/airthings/lib/logging/facility/JsonLoggerFacility.kt
@@ -133,7 +133,7 @@ class JsonLoggerFacility(
 
     init {
         coroutineScope.launch {
-            if (!io.isDirectory(baseFolder) && !io.mkdirs(baseFolder)) {
+            if (!io.mkdirs(baseFolder)) {
                 throw IllegalArgumentException("Base log folder is invalid: $baseFolder")
             }
         }

--- a/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutput.kt
+++ b/src/commonMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutput.kt
@@ -31,15 +31,10 @@ internal interface PlatformFileInputOutput : PlatformDirectoryListing {
     val pathSeparator: Char
 
     /**
-     * Returns true if the provided path points to a directory, false otherwise.
-     *
-     * @param path The location of the directory.
-     */
-    suspend fun isDirectory(path: String): Boolean
-
-    /**
      * Creates the provided [directory path][path], including any intermediary ones, and returns true on success,
      * false otherwise.
+     *
+     * If the directory already exists, then this method does nothing and returns true immediately.
      *
      * @param path The location of the directory.
      */

--- a/src/jvmMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputImpl.kt
+++ b/src/jvmMain/kotlin/com/airthings/lib/logging/platform/PlatformFileInputOutputImpl.kt
@@ -31,9 +31,13 @@ internal actual class PlatformFileInputOutputImpl : PlatformFileInputOutput {
 
     override val pathSeparator: Char = File.separatorChar
 
-    override suspend fun isDirectory(path: String): Boolean = File(path).isDirectory
+    override suspend fun mkdirs(path: String): Boolean {
+        val pathFile = File(path)
 
-    override suspend fun mkdirs(path: String): Boolean = File(path).mkdirs()
+        pathFile.mkdirs()
+
+        return pathFile.isDirectory
+    }
 
     override suspend fun size(path: String): Long = File(path).length()
 


### PR DESCRIPTION
A crash has been reported to happen that indicated that the base logging folder wasn't created. This bug fix is to tackle that, and at the same time to remove a redudant method (`isDirectory`) such that it becomes an interal and integral part of the implementation class.

The pr also bumps up the version of Kotlin, so the library version is bumped also to `0.2.0`.