### PR TITLE
Add privacy manifest

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,3 +198,25 @@ kmmbridge {
 }
 
 addGithubPackagesRepository()
+
+/**
+ * Apple requires 3rd party frameworks to include a privacy policy file.
+ *
+ * Based on a discussion on the Kotlin Slack, several people proposed the below solution to copy the privacy policy
+ * file to the framework output directory.
+ *
+ * Source: https://kotlinlang.slack.com/archives/C3PQML5NU/p1711715546770359
+ */
+rootProject.afterEvaluate {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink>().forEach { linkTask ->
+        val frameworkDestinationDir = linkTask.outputFile
+        linkTask.doLast {
+            rootProject.copy {
+                val privacyFile = rootProject.file("PrivacyInfo.xcprivacy")
+
+                from(privacyFile)
+                into(frameworkDestinationDir.get())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Apple requires 3rd party frameworks to include a privacy manifest file. Even though we don't use any privacy-sensitive APIs, it's better to be on the safe side and include the file anyway.