### PR TITLE
CI: Fix publishing v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,17 +6,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Clone code"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: "Lint code"
-        uses: ./.github/actions/lint
-
-  build:
+  build_and_publish:
     needs: lint
     runs-on: macos-latest
     steps:
@@ -24,25 +14,39 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: touchlab/read-property@0.1
+        id: versionPropertyValue
+        with:
+          file: ./gradle.properties
+          property: LIBRARY_VERSION # The release version. Defined in gradle.properties.
+
+      - name: "Print versionPropertyValue"
+        id: output
+        run: echo "${{ steps.versionPropertyValue.outputs.propVal }}"
+
       - name: "Set up Adopt OpenJDK 17"
         uses: ./.github/actions/java
-      - name: "Validate Gradle wrapper"
-        uses: gradle/actions/wrapper-validation@v4
-      - name: "Build code"
-        shell: sh
-        run: sh gradlew build
 
-  publish:
-    needs: build
-    runs-on: "macOS-14"
-    steps:
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: "Create or Find Artifact Release"
+        id: devrelease
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: "${{ steps.versionPropertyValue.outputs.propVal }}"
+
       - name: "Publish"
-        shell: sh
+        shell: sh"
         run: |
           pwd
           echo "Workspace: ${{ github.workspace }}"
           ls -l "${{ github.workspace }}/build/"
           sh gradlew kmmBridgePublish publishAllPublicationsToGitHubPackagesRepository \
+            -PGITHUB_ARTIFACT_RELEASE_ID=${{ steps.devrelease.outputs.id }} \
             -PENABLE_PUBLISHING=true \
             -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -PGITHUB_REPO=https://github.com/Airthings/KmpLog.git
+            -PGITHUB_REPO=${{ github.repository }}
+            --no-daemon --info --stacktrace


### PR DESCRIPTION
- Add some missing parts for KMMBridge publishing
- Remove linting from publishing because we guard linting errors on PRs and we cannot push to `main`