### PR TITLE
CI: Publish all publications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Publish"
         shell: sh
         run: |
-          sh gradlew publishKotlinMultiplatformPublicationToGitHubPackagesRepository publishAndroidReleasePublicationToGitHubPackagesRepository kmmBridgePublish \
+          sh gradlew kmmBridgePublish publishAllPublicationsToAirthingsGitHubPackagesRepository \
             -PGITHUB_ARTIFACT_RELEASE_ID=${{ steps.devrelease.outputs.id }} \
             -PENABLE_PUBLISHING=true \
             -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} \

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # Versioning:
 GROUP=com.airthings.lib
-LIBRARY_VERSION=0.2.20
+LIBRARY_VERSION=0.2.21
 
 # Gradle/KMP options:
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"


### PR DESCRIPTION
There are some missing artifacts, so revert to using the "publish all" option.